### PR TITLE
Fix pipe response deadlock and enforce install artifact sync

### DIFF
--- a/Plugins/LoomleBridge/Source/LoomleBridge/Private/LoomleBridgeModule.cpp
+++ b/Plugins/LoomleBridge/Source/LoomleBridge/Private/LoomleBridgeModule.cpp
@@ -1,6 +1,7 @@
 #include "LoomleBridgeModule.h"
 
 #include "Async/Async.h"
+#include "Async/Future.h"
 #include "Editor.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Algo/Sort.h"
@@ -1110,6 +1111,17 @@ void FLoomleBridgeModule::ShutdownModule()
 
 FString FLoomleBridgeModule::HandleRequest(const FString& RequestLine)
 {
+    if (!IsInGameThread())
+    {
+        TPromise<FString> ResponsePromise;
+        TFuture<FString> ResponseFuture = ResponsePromise.GetFuture();
+        AsyncTask(ENamedThreads::GameThread, [this, RequestLine, Promise = MoveTemp(ResponsePromise)]() mutable
+        {
+            Promise.SetValue(HandleRequest(RequestLine));
+        });
+        return ResponseFuture.Get();
+    }
+
     TSharedPtr<FJsonObject> RequestObject;
     TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(RequestLine);
 

--- a/Plugins/LoomleBridge/Source/LoomleBridge/Private/LoomlePipeServer.cpp
+++ b/Plugins/LoomleBridge/Source/LoomleBridge/Private/LoomlePipeServer.cpp
@@ -228,22 +228,14 @@ uint32 FLoomlePipeServer::Run()
                     continue;
                 }
 
-                TSharedPtr<FLoomlePipeServer, ESPMode::ThreadSafe> SharedSelf = AsShared();
                 FRequestHandler HandlerSnapshot = RequestHandler;
-                AsyncTask(ENamedThreads::GameThread, [SharedSelf, HandlerSnapshot, RequestLine, ConnectionSerial]()
+                const FString Response = HandlerSnapshot(RequestLine);
+                EndInFlight();
+                if (!Response.IsEmpty() && !WriteMessageForConnection(Response, ConnectionSerial))
                 {
-                    ON_SCOPE_EXIT
-                    {
-                        SharedSelf->EndInFlight();
-                    };
-
-                    const FString Response = HandlerSnapshot(RequestLine);
-                    if (!Response.IsEmpty() && !SharedSelf->WriteMessageForConnection(Response, ConnectionSerial))
-                    {
-                        UE_LOG(LogLoomlePipe, Verbose, TEXT("Dropping response for stale or disconnected pipe client"));
-                        return;
-                    }
-                });
+                    UE_LOG(LogLoomlePipe, Display, TEXT("Dropping response for stale or disconnected pipe client"));
+                    break;
+                }
             }
         }
 
@@ -356,22 +348,14 @@ uint32 FLoomlePipeServer::Run()
                     continue;
                 }
 
-                TSharedPtr<FLoomlePipeServer, ESPMode::ThreadSafe> SharedSelf = AsShared();
                 FRequestHandler HandlerSnapshot = RequestHandler;
-                AsyncTask(ENamedThreads::GameThread, [SharedSelf, HandlerSnapshot, RequestLine, ConnectionSerial]()
+                const FString Response = HandlerSnapshot(RequestLine);
+                EndInFlight();
+                if (!Response.IsEmpty() && !WriteMessageForConnection(Response, ConnectionSerial))
                 {
-                    ON_SCOPE_EXIT
-                    {
-                        SharedSelf->EndInFlight();
-                    };
-
-                    const FString Response = HandlerSnapshot(RequestLine);
-                    if (!Response.IsEmpty() && !SharedSelf->WriteMessageForConnection(Response, ConnectionSerial))
-                    {
-                        UE_LOG(LogLoomlePipe, Verbose, TEXT("Dropping response for stale or disconnected socket client"));
-                        return;
-                    }
-                });
+                    UE_LOG(LogLoomlePipe, Display, TEXT("Dropping response for stale or disconnected socket client"));
+                    break;
+                }
             }
         }
 

--- a/scripts/install_loomle.sh
+++ b/scripts/install_loomle.sh
@@ -344,6 +344,52 @@ PY
   fi
 }
 
+should_sync_root_artifacts() {
+  [[ -f "$ROOT_BIN" ]] || return 1
+
+  if [[ ! -f "$PLUGIN_BIN" ]]; then
+    return 0
+  fi
+
+  if [[ "$ROOT_BIN" -nt "$PLUGIN_BIN" ]]; then
+    return 0
+  fi
+
+  local root_size plugin_size
+  root_size="$(wc -c < "$ROOT_BIN" | tr -d '[:space:]')"
+  plugin_size="$(wc -c < "$PLUGIN_BIN" | tr -d '[:space:]')"
+  if [[ "$root_size" != "$plugin_size" ]]; then
+    return 0
+  fi
+
+  if [[ -f "$ROOT_MODULES" ]]; then
+    if [[ ! -f "$PLUGIN_MODULES" ]]; then
+      return 0
+    fi
+
+    local ids root_build plugin_build
+    ids="$(
+      python3 - <<'PY' "$ROOT_MODULES" "$PLUGIN_MODULES"
+import json
+import pathlib
+import sys
+root_data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+plugin_data = json.loads(pathlib.Path(sys.argv[2]).read_text())
+print(str(root_data.get("BuildId", "")).strip())
+print(str(plugin_data.get("BuildId", "")).strip())
+PY
+    )" || return 0
+
+    root_build="$(printf '%s\n' "$ids" | sed -n '1p')"
+    plugin_build="$(printf '%s\n' "$ids" | sed -n '2p')"
+    if [[ "$root_build" != "$plugin_build" ]]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
 if [[ "$SKIP_BUILD" -eq 0 ]]; then
   [[ -x "$GEN_SCRIPT" ]] || fail "GenerateProjectFiles script missing: $GEN_SCRIPT"
   [[ -x "$BUILD_SCRIPT" ]] || fail "Build script missing: $BUILD_SCRIPT"
@@ -371,6 +417,13 @@ if [[ "$SKIP_BUILD" -eq 0 ]]; then
   fi
 else
   log "Skipping build (--skip-build)"
+fi
+
+if should_sync_root_artifacts; then
+  log "Synchronizing root build artifacts to plugin directory"
+  sync_built_plugin_artifacts
+else
+  log "Plugin binary artifacts already synchronized"
 fi
 
 if [[ "$SKIP_LAUNCH" -eq 0 ]]; then

--- a/scripts/install_loomle_windows.ps1
+++ b/scripts/install_loomle_windows.ps1
@@ -197,6 +197,52 @@ function Sync-BuiltPluginArtifacts {
     }
 }
 
+function Test-ShouldSyncRootArtifacts {
+    param(
+        [Parameter(Mandatory = $true)][string]$RootBin,
+        [Parameter(Mandatory = $true)][string]$RootModules,
+        [Parameter(Mandatory = $true)][string]$PluginBin,
+        [Parameter(Mandatory = $true)][string]$PluginModules
+    )
+
+    if (-not (Test-Path -LiteralPath $RootBin)) {
+        return $false
+    }
+
+    if (-not (Test-Path -LiteralPath $PluginBin)) {
+        return $true
+    }
+
+    $rootItem = Get-Item -LiteralPath $RootBin
+    $pluginItem = Get-Item -LiteralPath $PluginBin
+    if ($rootItem.LastWriteTimeUtc -gt $pluginItem.LastWriteTimeUtc) {
+        return $true
+    }
+    if ($rootItem.Length -ne $pluginItem.Length) {
+        return $true
+    }
+
+    if (Test-Path -LiteralPath $RootModules) {
+        if (-not (Test-Path -LiteralPath $PluginModules)) {
+            return $true
+        }
+
+        $rootObj = Read-JsonFile -Path $RootModules
+        $pluginObj = Read-JsonFile -Path $PluginModules
+        if ($null -eq $rootObj -or $null -eq $pluginObj) {
+            return $true
+        }
+
+        $rootBuildId = [string]$rootObj.BuildId
+        $pluginBuildId = [string]$pluginObj.BuildId
+        if (-not [string]::Equals($rootBuildId, $pluginBuildId, [System.StringComparison]::Ordinal)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function Send-BridgeRequest {
     param(
         [Parameter(Mandatory = $true)][System.IO.StreamWriter]$Writer,
@@ -416,6 +462,14 @@ try {
     }
     else {
         Log 'Skipping build (--skip-build)'
+    }
+
+    if (Test-ShouldSyncRootArtifacts -RootBin $rootBin -RootModules $rootModules -PluginBin $pluginBin -PluginModules $pluginModules) {
+        Log 'Synchronizing root build artifacts to plugin directory'
+        Sync-BuiltPluginArtifacts -RootBin $rootBin -RootModules $rootModules -PluginBin $pluginBin -PluginModules $pluginModules
+    }
+    else {
+        Log 'Plugin binary artifacts already synchronized'
     }
 
     if (-not $SkipLaunch) {


### PR DESCRIPTION
## Summary
- fix Loomle bridge named-pipe response deadlock where requests were read but initialize/tools responses could hang and timeout
- ensure request handling always executes on the game thread while pipe IO remains on the pipe thread
- harden install flows to always synchronize root build artifacts into plugin binaries when drift is detected
- apply the artifact-sync hardening to both Windows and mac/Linux installers

## Details
- move pipe response write path out of async game-thread lambda to avoid blocking pipe read/write on the same handle
- add a game-thread handoff inside \HandleRequest\ when invoked from non-game threads
- add post-build/post-skip drift checks for binary timestamp/size/modules BuildId and auto-sync when needed

## Validation
- confirmed \initialize\ and \	ools/list\ return immediately after restart
- confirmed \	ools/call(name=loomle)\ returns healthy status
- verified installer scripts include the new artifact drift synchronization path on Windows and mac/Linux