### PR TITLE
fix(sal): avoid depending on FJsonObject key storage type

### DIFF
--- a/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/Blueprint/SalBlueprintInterface.cpp
+++ b/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/Blueprint/SalBlueprintInterface.cpp
@@ -1843,13 +1843,18 @@ void AppendCanonicalJson(FString& Out, const TSharedPtr<FJsonValue>& Json)
     if (Json->TryGetObject(Object) && Object != nullptr && (*Object).IsValid())
     {
         TArray<FString> Keys;
-        (*Object)->Values.GetKeys(Keys);
+        // Values keys are FString before UE 5.8 and UE::FSharedString from
+        // 5.8 on. operator* yields const TCHAR* for both, so this copy
+        // compiles against either engine version.
+        for (const auto& Pair : (*Object)->Values) Keys.Add(FString(*Pair.Key));
         Keys.Sort();
         Out += TEXT("o{");
         for (const FString& Key : Keys)
         {
             AppendCursorToken(Out, TEXT('k'), Key);
-            AppendCanonicalJson(Out, (*Object)->Values.FindRef(Key));
+            // TryGetField takes an FString on both engine versions;
+            // Values.FindRef cannot from UE 5.8 on.
+            AppendCanonicalJson(Out, (*Object)->TryGetField(Key));
         }
         Out += TEXT("};");
         return;

--- a/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/Graph/SalGraphInterface.cpp
+++ b/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/Graph/SalGraphInterface.cpp
@@ -193,7 +193,10 @@ FString ExprNativeText(const TSharedPtr<FJsonValue>& Value)
     }
     if (DecodedObject->TryGetStringField(TEXT("id"), String)) return String;
     TArray<FString> Keys;
-    DecodedObject->Values.GetKeys(Keys);
+    // Values keys are FString before UE 5.8 and UE::FSharedString from
+    // 5.8 on. operator* yields const TCHAR* for both, so this copy
+    // compiles against either engine version.
+    for (const auto& Pair : DecodedObject->Values) Keys.Add(FString(*Pair.Key));
     Keys.Sort();
     TArray<FString> Fields;
     for (const FString& Key : Keys)

--- a/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/Reference/SalReferenceInterface.cpp
+++ b/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/Reference/SalReferenceInterface.cpp
@@ -235,13 +235,18 @@ void AppendCanonicalJson(FString& Out, const TSharedPtr<FJsonValue>& Json)
     if (Json->TryGetObject(Object) && Object != nullptr && (*Object).IsValid())
     {
         TArray<FString> Keys;
-        (*Object)->Values.GetKeys(Keys);
+        // Values keys are FString before UE 5.8 and UE::FSharedString from
+        // 5.8 on. operator* yields const TCHAR* for both, so this copy
+        // compiles against either engine version.
+        for (const auto& Pair : (*Object)->Values) Keys.Add(FString(*Pair.Key));
         Keys.Sort();
         Out += TEXT("o{");
         for (const FString& Key : Keys)
         {
             AppendToken(Out, TEXT('k'), Key);
-            AppendCanonicalJson(Out, (*Object)->Values.FindRef(Key));
+            // TryGetField takes an FString on both engine versions;
+            // Values.FindRef cannot from UE 5.8 on.
+            AppendCanonicalJson(Out, (*Object)->TryGetField(Key));
         }
         Out += TEXT("};");
         return;

--- a/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/SalModule.cpp
+++ b/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/SalModule.cpp
@@ -1822,13 +1822,18 @@ void AppendCanonicalJson(FString& Out, const TSharedPtr<FJsonValue>& Value)
     if (Value->TryGetObject(Object) && Object != nullptr && (*Object).IsValid())
     {
         TArray<FString> Keys;
-        (*Object)->Values.GetKeys(Keys);
+        // Values keys are FString before UE 5.8 and UE::FSharedString from
+        // 5.8 on. operator* yields const TCHAR* for both, so this copy
+        // compiles against either engine version.
+        for (const auto& Pair : (*Object)->Values) Keys.Add(FString(*Pair.Key));
         Keys.Sort();
         Out += TEXT("o{");
         for (const FString& Key : Keys)
         {
             AppendCursorToken(Out, TEXT('k'), Key);
-            AppendCanonicalJson(Out, (*Object)->Values.FindRef(Key));
+            // TryGetField takes an FString on both engine versions;
+            // Values.FindRef cannot from UE 5.8 on.
+            AppendCanonicalJson(Out, (*Object)->TryGetField(Key));
         }
         Out += TEXT("};");
         return;

--- a/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/StateTree/SalStateTreePatch.cpp
+++ b/engine/LoomleBridge/Source/LoomleBridge/Private/Sal/StateTree/SalStateTreePatch.cpp
@@ -2509,7 +2509,10 @@ bool ApplyConstructorFields(
     const FCreatedRef& Created)
 {
     TArray<FString> Keys;
-    Definition.Args->Values.GetKeys(Keys);
+    // Values keys are FString before UE 5.8 and UE::FSharedString from
+    // 5.8 on. operator* yields const TCHAR* for both, so this copy
+    // compiles against either engine version.
+    for (const auto& Pair : Definition.Args->Values) Keys.Add(FString(*Pair.Key));
     Keys.Remove(TEXT("palette"));
     if (Created.Kind == TEXT("parameter"))
     {
@@ -3467,7 +3470,10 @@ FString NativeExpressionText(
     const FStructProperty* StructProperty = CastField<FStructProperty>(Property);
     TArray<FString> Fields;
     TArray<FString> Keys;
-    DecodedObject->Values.GetKeys(Keys);
+    // Values keys are FString before UE 5.8 and UE::FSharedString from
+    // 5.8 on. operator* yields const TCHAR* for both, so this copy
+    // compiles against either engine version.
+    for (const auto& Pair : DecodedObject->Values) Keys.Add(FString(*Pair.Key));
     Keys.Sort();
     for (const FString& Key : Keys)
     {


### PR DESCRIPTION
UE 5.8 changed FJsonObject::Values from TMap<FString, ...> to TMap<UE::FSharedString, ...>, breaking nine sites that bypass the public API.

Each site is commented so it isn't simplified back.
- Values.FindRef(Key) → TryGetField(Key) - public accessor, predates 5.8, same null-on-absent result; callers already null-check.
- Values.GetKeys(Keys) → range-for copying FString(*Pair.Key) - no public enumeration API; operator* gives const TCHAR* for both key types.

UE_JSONOBJECT_LEGACY_STRING_KEYS=1 isn't a way out.   (Per-module it's silently ineffective.)

Build against 5.8.0 (src) is clean. Building with Private/Tests also needs bUseUnity = false (pre-existing duplicate-symbol collision, unrelated to this change). Not verified on 5.7 — no 5.7 engine here.